### PR TITLE
Create sticker sheet planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
-# Ping Pong Game
+# Sticker Lab – Planejamento de cartelas A4/A5/A6
 
-Este repositório hospeda uma aplicação simples de Ping Pong utilizando HTML5 canvas.
-A página está disponível em [https://baiteryamato.github.io/](https://baiteryamato.github.io/).
+Aplicação em estilo duolingo/neumorfismo para organizar e agrupar adesivos (die-cut e fundo transparente) em folhas A4, A5 ou A6. Faça upload de vários PNGs, defina contorno e margem individual, quantidade por arte, unidade desejada (px, mm ou cm) e veja o live preview ocupar a folha inteira.
+
+## Como executar
+1. Instale dependências do servidor (Flask):
+   ```bash
+   pip install flask
+   ```
+2. Inicie o app em modo local:
+   ```bash
+   python app.py
+   ```
+3. Abra `http://localhost:8000` para usar o planner com preview e packing automático.
+
+## Recursos rápidos
+- Upload múltiplo com leitura da proporção da imagem.
+- Margem externa, espaçamento entre adesivos e contorno configurável por sticker.
+- Medidas em px/mm/cm e tamanhos de folha A4, A5 ou A6 com orientação retrato/paisagem.
+- Algoritmo que rotaciona e organiza para economizar papel, com múltiplas páginas quando necessário.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,142 @@
+from flask import Flask, jsonify, request, send_from_directory
+from typing import Dict, List
+
+app = Flask(__name__, static_folder='.', static_url_path='')
+
+
+def pack_stickers(payload: Dict) -> Dict:
+    sheet_width = float(payload.get("sheetWidthMm", 210))
+    sheet_height = float(payload.get("sheetHeightMm", 297))
+    margin = max(float(payload.get("marginMm", 5)), 0)
+    gap = max(float(payload.get("gapMm", 2)), 0)
+    stickers: List[Dict] = payload.get("stickers", [])
+
+    def expanded_items():
+        for sticker in stickers:
+            qty = max(int(sticker.get("quantity", 1)), 0)
+            base_width = float(sticker.get("widthMm", 30))
+            base_height = float(sticker.get("heightMm", 30))
+            contour = max(float(sticker.get("contourMm", 0)), 0)
+            extra_gap = max(float(sticker.get("extraGapMm", 0)), 0)
+            allow_rotation = bool(sticker.get("allowRotation", True))
+            for _ in range(qty):
+                yield {
+                    "id": sticker.get("id"),
+                    "name": sticker.get("name", "adesivo"),
+                    "width": base_width + (contour * 2),
+                    "height": base_height + (contour * 2),
+                    "contour": contour,
+                    "contourColor": sticker.get("contourColor", "#22c55e"),
+                    "allowRotation": allow_rotation,
+                    "extraGap": extra_gap,
+                }
+
+    pages: List[Dict] = []
+    current_page: List[Dict] = []
+    x = margin
+    y = margin
+    row_height = 0
+
+    def start_new_page():
+        nonlocal current_page, x, y, row_height
+        if current_page:
+            pages.append({
+                "placements": current_page,
+                "sheetWidth": sheet_width,
+                "sheetHeight": sheet_height,
+                "margin": margin,
+            })
+        current_page = []
+        x = margin
+        y = margin
+        row_height = 0
+
+    start_new_page()
+
+    for item in expanded_items():
+        placed = False
+        for rotated in ([False, True] if item["allowRotation"] else [False]):
+            w = item["height"] if rotated else item["width"]
+            h = item["width"] if rotated else item["height"]
+            inner_gap = gap + item["extraGap"]
+
+            fits_current_row = x + w <= sheet_width - margin and y + h <= sheet_height - margin
+            if fits_current_row:
+                current_page.append({
+                    **item,
+                    "x": x,
+                    "y": y,
+                    "width": w,
+                    "height": h,
+                    "rotated": rotated,
+                })
+                x += w + inner_gap
+                row_height = max(row_height, h)
+                placed = True
+                break
+
+            new_row_y = y + row_height + inner_gap
+            fits_new_row = w <= sheet_width - (margin * 2) and new_row_y + h <= sheet_height - margin
+            if fits_new_row:
+                x = margin
+                y = new_row_y
+                row_height = h
+                current_page.append({
+                    **item,
+                    "x": x,
+                    "y": y,
+                    "width": w,
+                    "height": h,
+                    "rotated": rotated,
+                })
+                x += w + inner_gap
+                placed = True
+                break
+
+        if not placed:
+            start_new_page()
+            x = margin
+            y = margin
+            row_height = 0
+            # place on fresh page (without rotation retry loop)
+            w = item["width"]
+            h = item["height"]
+            rotated = False
+            if item["allowRotation"] and h <= sheet_width - (margin * 2) and w > sheet_width - (margin * 2):
+                w, h = h, w
+                rotated = True
+            current_page.append({
+                **item,
+                "x": x,
+                "y": y,
+                "width": w,
+                "height": h,
+                "rotated": rotated,
+            })
+            x += w + gap + item.get("extraGap", 0)
+            row_height = max(row_height, h)
+
+    if current_page:
+        pages.append({
+            "placements": current_page,
+            "sheetWidth": sheet_width,
+            "sheetHeight": sheet_height,
+            "margin": margin,
+        })
+
+    return {"pages": pages}
+
+
+@app.route('/')
+def index():
+    return send_from_directory('.', 'index.html')
+
+
+@app.route('/pack', methods=['POST'])
+def pack_endpoint():
+    payload = request.get_json(force=True)
+    return jsonify(pack_stickers(payload))
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000, debug=False)

--- a/css/style.css
+++ b/css/style.css
@@ -1,65 +1,227 @@
+:root {
+  --bg: #e6f5e8;
+  --card: #f7fbf8;
+  --accent: #6ee07a;
+  --accent-strong: #2fb344;
+  --text: #0f172a;
+  --muted: #5f6b7a;
+  --shadow: 14px 14px 28px rgba(12, 98, 46, 0.16), -12px -12px 22px rgba(255, 255, 255, 0.8);
+  --radius: 18px;
+  --transition: all 0.25s ease;
+}
+
+* { box-sizing: border-box; }
 body {
   margin: 0;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, #f2fff3, #e0f2e5 55%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+a { color: inherit; }
+
+.app-header {
+  padding: 18px 32px;
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
   align-items: center;
-  justify-content: center;
-  height: 100vh;
-  background: #222;
-  color: #fff;
-  font-family: Arial, sans-serif;
-5582pl-codex/refazer-aplicação-de-ping-pong
-}
-
-h1 {
-  margin-bottom: 20px;
-}
-
-#score {
-  font-size: 24px;
-  margin-bottom: 10px;
-}
-
-canvas {
-  background: #000;
-  border: 2px solid #fff;
-}
-
-#gameOver {
-  position: absolute;
+  position: sticky;
   top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(12px);
+  background: rgba(230, 245, 232, 0.8);
+  z-index: 10;
+}
+
+.logo {
+  font-weight: 800;
+  font-size: 20px;
+  color: var(--accent-strong);
+  letter-spacing: 0.5px;
+}
+
+.header-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 24px;
+  padding: 0 28px 48px;
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 20px;
+  border: 1px solid rgba(47, 179, 68, 0.06);
+}
+
+.hero h1 { margin: 8px 0; }
+.hero p { color: var(--muted); margin: 4px 0 14px; }
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.field {
   display: flex;
   flex-direction: column;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.field input,
+.field select {
+  width: 100%;
+  border: none;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: #f2fbf3;
+  box-shadow: inset 4px 4px 8px rgba(12, 98, 46, 0.14), inset -4px -4px 8px rgba(255, 255, 255, 0.8);
+  color: var(--text);
+  transition: var(--transition);
+}
+
+.field input:focus,
+.field select:focus { outline: 2px solid rgba(47, 179, 68, 0.3); }
+
+button {
+  border: none;
+  border-radius: 14px;
+  padding: 12px 16px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: var(--transition);
+  box-shadow: var(--shadow);
+  background: #f1faf2;
+  color: var(--text);
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0b2a0f;
+}
+
+button.ghost {
+  background: #f7fbf8;
+  color: var(--muted);
+}
+
+button:hover { transform: translateY(-1px); }
+button:active { transform: translateY(0); box-shadow: none; }
+
+.pill {
+  background: #f1faf2;
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 10px 16px;
+  box-shadow: var(--shadow);
+  font-weight: 600;
+}
+
+.upload-card .upload-header { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; }
+
+.dropzone {
+  margin-top: 12px;
+  padding: 20px;
+  border-radius: var(--radius);
+  border: 2px dashed rgba(47, 179, 68, 0.3);
+  background: #f9fdf8;
+  text-align: center;
+  color: var(--muted);
+  position: relative;
+}
+
+.dropzone input[type="file"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.sticker-list { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; margin-top: 14px; }
+
+.sticker-card {
+  padding: 14px;
+  border-radius: 16px;
+  background: #f8fdf9;
+  box-shadow: inset 6px 6px 12px rgba(12, 98, 46, 0.08), inset -6px -6px 12px rgba(255, 255, 255, 0.9);
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 12px;
   align-items: center;
+}
+
+.sticker-card img {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  border-radius: 12px;
+  background: white;
+  box-shadow: inset 2px 2px 4px rgba(0,0,0,0.06);
+}
+
+.sticker-fields { display: grid; grid-template-columns: repeat(2, minmax(90px, 1fr)); gap: 8px; align-items: center; }
+
+.sticker-meta { display: flex; justify-content: space-between; align-items: center; color: var(--muted); font-weight: 600; }
+
+.preview-card { height: 100%; display: flex; flex-direction: column; gap: 12px; }
+.preview-header { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+
+.sheet-wrapper {
+  background: linear-gradient(145deg, #f5fbf6, #e9f6ea);
+  border-radius: 18px;
+  box-shadow: inset 8px 8px 16px rgba(12, 98, 46, 0.08), inset -8px -8px 16px rgba(255, 255, 255, 0.9);
+  padding: 18px;
+  display: flex;
   justify-content: center;
+  align-items: center;
 }
 
-.hidden {
-  display: none;
+#sheetCanvas {
+  width: 100%;
+  height: 70vh;
+  max-height: 700px;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
 }
 
-#ranking {
-  margin-top: 20px;
-  text-align: left;
-}
-=======
-}
-
-h1 {
-  margin-bottom: 20px;
-}
-
-#score {
-  font-size: 24px;
-  margin-bottom: 10px;
+.badges { display: flex; flex-wrap: wrap; gap: 8px; }
+.badges span {
+  background: #eef8ef;
+  color: var(--accent-strong);
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-weight: 700;
+  box-shadow: inset 2px 2px 4px rgba(12,98,46,0.08), inset -2px -2px 4px rgba(255,255,255,0.8);
 }
 
-canvas {
-  background: #000;
-  border: 2px solid #fff;
+.eyebrow { text-transform: uppercase; letter-spacing: 0.08em; font-weight: 800; color: var(--accent-strong); font-size: 12px; }
+
+.preview-actions { display: flex; gap: 8px; align-items: center; }
+
+footer {
+  padding: 18px 28px 32px;
+  color: var(--muted);
 }
-main
+
+@media (max-width: 1040px) {
+  .layout { grid-template-columns: 1fr; }
+  #sheetCanvas { height: 60vh; }
+}
+
+@media (max-width: 720px) {
+  .upload-card .upload-header { flex-direction: column; }
+  .preview-header { flex-direction: column; align-items: flex-start; }
+  .sticker-card { grid-template-columns: 1fr; }
+  .sticker-card img { justify-self: center; }
+}

--- a/index.html
+++ b/index.html
@@ -2,25 +2,118 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8">
-  <title>Ping Pong MVP</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Planner de Adesivos Die-cut</title>
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Ping Pong</h1>
-5582pl-codex/refazer-aplicação-de-ping-pong
-  <div id="score">Score: 0</div>
-  <canvas id="gameCanvas" width="800" height="400"></canvas>
-  <div id="gameOver" class="hidden">
-    <p>Game Over</p>
-    <p>Digite seu nome e pressione Enter</p>
-    <input id="nameInput" type="text" placeholder="Seu nome">
-  </div>
-  <h2>Ranking</h2>
-  <ol id="ranking"></ol>
+  <header class="app-header">
+    <div class="logo">Sticker Lab</div>
+    <div class="header-actions">
+      <button class="ghost" id="clearBoard">Limpar grade</button>
+      <div class="pill">Live preview automático • folha completa na tela</div>
+    </div>
+  </header>
 
-  <div id="score">0 : 0</div>
-  <canvas id="gameCanvas" width="800" height="400"></canvas>
-main
+  <main class="layout">
+    <section class="controls">
+      <div class="card hero">
+        <div>
+          <p class="eyebrow">Estilo Duolingo · Neumorfismo</p>
+          <h1>Monte cartelas A4/A5/A6 com recorte die-cut e fundo transparente</h1>
+          <p>Envie um lote de adesivos, defina contorno, espaçamento e tamanhos individuais. O planner rotaciona e organiza cada arte para ocupar o menor espaço possível.</p>
+          <div class="settings-grid">
+            <label class="field">
+              <span>Tamanho da folha</span>
+              <select id="sheetSize">
+                <option value="A4">A4</option>
+                <option value="A5">A5</option>
+                <option value="A6">A6</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Orientação</span>
+              <select id="orientation">
+                <option value="portrait">Retrato</option>
+                <option value="landscape">Paisagem</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Unidade</span>
+              <select id="unitSelect">
+                <option value="mm">mm</option>
+                <option value="cm">cm</option>
+                <option value="px">px</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Margem externa</span>
+              <input type="number" id="marginInput" min="0" step="0.5" value="5">
+            </label>
+            <label class="field">
+              <span>Espaçamento entre adesivos</span>
+              <input type="number" id="gapInput" min="0" step="0.5" value="2">
+            </label>
+            <label class="field">
+              <span>Cor do contorno padrão</span>
+              <input type="color" id="defaultContourColor" value="#22c55e">
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <div class="card upload-card">
+        <div class="upload-header">
+          <div>
+            <h2>Upload de adesivos</h2>
+            <p>Arraste PNGs com fundo transparente ou clique para buscar. Ajuste quantidades e contornos individualmente.</p>
+          </div>
+          <div class="mini-settings">
+            <label class="field compact">
+              <span>Pré-visualizar medidas em</span>
+              <select id="previewUnit">
+                <option value="mm">mm</option>
+                <option value="cm">cm</option>
+                <option value="px">px</option>
+              </select>
+            </label>
+          </div>
+        </div>
+        <div id="dropZone" class="dropzone">
+          <input type="file" id="fileInput" accept="image/*" multiple>
+          <p>Solte as imagens aqui ou clique para selecionar</p>
+          <small>O planner lê proporção, permite rotacionar e replica cada arte conforme a quantidade definida.</small>
+        </div>
+        <div id="stickerList" class="sticker-list"></div>
+      </div>
+    </section>
+
+    <section class="preview">
+      <div class="card preview-card">
+        <div class="preview-header">
+          <div>
+            <p class="eyebrow">Live preview</p>
+            <h2>Cartela pronta para corte</h2>
+            <p id="pageIndicator">Página 1 de 1</p>
+          </div>
+          <div class="preview-actions">
+            <button class="ghost" id="prevPage">◀</button>
+            <button class="ghost" id="nextPage">▶</button>
+            <button class="primary" id="repack">Recalcular</button>
+          </div>
+        </div>
+        <div class="sheet-wrapper">
+          <svg id="sheetCanvas" aria-label="preview da folha"></svg>
+        </div>
+        <div class="badges" id="summaryBadges"></div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>Dicas: use PNG com contorno transparente; ajuste contorno em mm/cm/px; veja ocupação e número de páginas antes de imprimir.</p>
+  </footer>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,151 +1,465 @@
-const canvas = document.getElementById('gameCanvas');
-const ctx = canvas.getContext('2d');
+const A_SIZES = {
+  A4: { width: 210, height: 297 },
+  A5: { width: 148, height: 210 },
+  A6: { width: 105, height: 148 },
+};
 
-const paddleWidth = 10;
-const paddleHeight = 80;
-const player = { x: 10, y: 0, dy: 5 };
-const ai = { x: canvas.width - paddleWidth - 10, y: 0, dy: 5 };
-const ball = { x: 0, y: 0, radius: 7, dx: 4, dy: 4 };
+const mmPerPx = 25.4 / 96;
+let stickers = [];
+let pages = [{ placements: [], sheetWidth: A_SIZES.A4.width, sheetHeight: A_SIZES.A4.height, margin: 5 }];
+let currentPageIndex = 0;
+let currentUnit = 'mm';
 
-let playerScore = 0;
-let running = false;
-const scoreEl = document.getElementById('score');
-const gameOverEl = document.getElementById('gameOver');
-const nameInput = document.getElementById('nameInput');
-const rankingEl = document.getElementById('ranking');
-let running = true;
-let aiScore = 0;
-const scoreEl = document.getElementById('score');
-main
+const sheetCanvas = document.getElementById('sheetCanvas');
+const stickerList = document.getElementById('stickerList');
+const marginInput = document.getElementById('marginInput');
+const gapInput = document.getElementById('gapInput');
+const sheetSizeSelect = document.getElementById('sheetSize');
+const orientationSelect = document.getElementById('orientation');
+const unitSelect = document.getElementById('unitSelect');
+const previewUnit = document.getElementById('previewUnit');
+const pageIndicator = document.getElementById('pageIndicator');
+const summaryBadges = document.getElementById('summaryBadges');
+const defaultContourColor = document.getElementById('defaultContourColor');
 
-let upPressed = false;
-let downPressed = false;
+const dropZone = document.getElementById('dropZone');
+const fileInput = document.getElementById('fileInput');
 
-document.addEventListener('keydown', (e) => {
-  if (e.key === 'ArrowUp' || e.key === 'w') upPressed = true;
-  if (e.key === 'ArrowDown' || e.key === 's') downPressed = true;
+document.getElementById('repack').addEventListener('click', packAndRender);
+document.getElementById('prevPage').addEventListener('click', () => changePage(-1));
+document.getElementById('nextPage').addEventListener('click', () => changePage(1));
+document.getElementById('clearBoard').addEventListener('click', () => {
+  stickers = [];
+  pages = [emptyPage()];
+  renderStickerList();
+  renderPreview();
 });
 
-document.addEventListener('keyup', (e) => {
-  if (e.key === 'ArrowUp' || e.key === 'w') upPressed = false;
-  if (e.key === 'ArrowDown' || e.key === 's') downPressed = false;
+[sheetSizeSelect, orientationSelect, marginInput, gapInput].forEach((el) => {
+  el.addEventListener('input', packAndRender);
 });
 
-function update() {
-  if (upPressed && player.y > 0) player.y -= player.dy;
-  if (downPressed && player.y < canvas.height - paddleHeight) player.y += player.dy;
-
-  if (ai.y + paddleHeight / 2 < ball.y) ai.y += ai.dy;
-  else if (ai.y + paddleHeight / 2 > ball.y) ai.y -= ai.dy;
-  ai.y = Math.max(Math.min(ai.y, canvas.height - paddleHeight), 0);
-
-  ball.x += ball.dx;
-  ball.y += ball.dy;
-
-  if (ball.y + ball.radius > canvas.height || ball.y - ball.radius < 0) ball.dy = -ball.dy;
-
-  if (ball.x - ball.radius < player.x + paddleWidth && ball.y > player.y && ball.y < player.y + paddleHeight) {
-    ball.dx = -ball.dx;
-    ball.x = player.x + paddleWidth + ball.radius;
-  }
-  if (ball.x + ball.radius > ai.x && ball.y > ai.y && ball.y < ai.y + paddleHeight) {
-    ball.dx = -ball.dx;
-    ball.x = ai.x - ball.radius;
-  }
-
-  if (ball.x - ball.radius < 0) {
-5582pl-codex/refazer-aplicação-de-ping-pong
-    endGame();
-  }
-  if (ball.x + ball.radius > canvas.width) {
-    playerScore++;
-function startGame() {
-  player.y = canvas.height / 2 - paddleHeight / 2;
-  ai.y = canvas.height / 2 - paddleHeight / 2;
-  resetBall(Math.random() > 0.5 ? 1 : -1);
-  playerScore = 0;
-  scoreEl.textContent = `Score: ${playerScore}`;
-  running = true;
-  gameOverEl.classList.add('hidden');
-  requestAnimationFrame(loop);
-}
-
-startGame();
-    startGame();
-  if (ball.x + ball.radius > canvas.width) {
-    playerScore++;
-    resetBall(1);
-  }
-
-  scoreEl.textContent = `${playerScore} : ${aiScore}`;
-main
-}
-
-function resetBall(direction) {
-  ball.x = canvas.width / 2;
-  ball.y = canvas.height / 2;
-  ball.dx = 4 * direction;
-  ball.dy = 4 * (Math.random() > 0.5 ? 1 : -1);
-}
-
-function draw() {
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.fillStyle = '#fff';
-  ctx.fillRect(player.x, player.y, paddleWidth, paddleHeight);
-  ctx.fillRect(ai.x, ai.y, paddleWidth, paddleHeight);
-  ctx.beginPath();
-  ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
-  ctx.fill();
-}
-
-function loop() {
-5582pl-codex/refazer-aplicação-de-ping-pong
-  if (!running) return;
-main
-  update();
-  draw();
-  requestAnimationFrame(loop);
-}
-
-loop();
-5582pl-codex/refazer-aplicação-de-ping-pong
-
-function endGame() {
-  running = false;
-  gameOverEl.classList.remove('hidden');
-  nameInput.focus();
-}
-
-nameInput.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter' && nameInput.value.trim() !== '') {
-    saveScore(nameInput.value.trim());
-    nameInput.value = '';
-    gameOverEl.classList.add('hidden');
-    resetBall(1);
-    playerScore = 0;
-    scoreEl.textContent = `Score: ${playerScore}`;
-    running = true;
-    requestAnimationFrame(loop);
-  }
+unitSelect.addEventListener('change', (e) => {
+  currentUnit = e.target.value;
+  renderStickerList();
 });
 
-function saveScore(name) {
-  const ranking = JSON.parse(localStorage.getItem('ranking') || '[]');
-  ranking.push({ name, score: playerScore });
-  ranking.sort((a, b) => b.score - a.score);
-  localStorage.setItem('ranking', JSON.stringify(ranking));
-  updateRanking();
+previewUnit.addEventListener('change', () => {
+  renderStickerList();
+  renderPreview();
+});
+
+dropZone.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  dropZone.classList.add('dragging');
+});
+
+dropZone.addEventListener('dragleave', () => dropZone.classList.remove('dragging'));
+
+dropZone.addEventListener('drop', (e) => {
+  e.preventDefault();
+  dropZone.classList.remove('dragging');
+  handleFiles(e.dataTransfer.files);
+});
+
+fileInput.addEventListener('change', (e) => handleFiles(e.target.files));
+
+function emptyPage() {
+  const { width, height } = getSheetSize();
+  return { placements: [], sheetWidth: width, sheetHeight: height, margin: toMm(parseFloat(marginInput.value) || 0, currentUnit) };
 }
 
-function updateRanking() {
-  const ranking = JSON.parse(localStorage.getItem('ranking') || '[]');
-  rankingEl.innerHTML = '';
-  ranking.slice(0, 10).forEach((entry) => {
-    const li = document.createElement('li');
-    li.textContent = `${entry.name} - ${entry.score}`;
-    rankingEl.appendChild(li);
+function toMm(value, unit = currentUnit) {
+  if (Number.isNaN(value)) return 0;
+  switch (unit) {
+    case 'cm':
+      return value * 10;
+    case 'px':
+      return value * mmPerPx;
+    default:
+      return value;
+  }
+}
+
+function fromMm(value, unit = currentUnit) {
+  switch (unit) {
+    case 'cm':
+      return value / 10;
+    case 'px':
+      return value / mmPerPx;
+    default:
+      return value;
+  }
+}
+
+function getSheetSize() {
+  const base = A_SIZES[sheetSizeSelect.value] || A_SIZES.A4;
+  const portrait = orientationSelect.value === 'portrait';
+  return portrait
+    ? { width: base.width, height: base.height }
+    : { width: base.height, height: base.width };
+}
+
+function handleFiles(fileList) {
+  const files = Array.from(fileList);
+  files.forEach((file) => {
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const img = new Image();
+      img.onload = () => {
+        const naturalWidthMm = img.naturalWidth * mmPerPx;
+        const naturalHeightMm = img.naturalHeight * mmPerPx;
+        const targetWidth = Math.min(60, naturalWidthMm || 40);
+        const targetHeight = (targetWidth / naturalWidthMm) * naturalHeightMm || 40;
+        stickers.push({
+          id: crypto.randomUUID(),
+          name: file.name,
+          src: ev.target.result,
+          widthMm: targetWidth,
+          heightMm: targetHeight,
+          quantity: 1,
+          contourMm: 0,
+          contourColor: defaultContourColor.value,
+          allowRotation: true,
+          extraGapMm: 0,
+        });
+        renderStickerList();
+        packAndRender();
+      };
+      img.src = ev.target.result;
+    };
+    reader.readAsDataURL(file);
   });
 }
 
-updateRanking();
-main
+function renderStickerList() {
+  stickerList.innerHTML = '';
+  const unitLabel = previewUnit.value;
+
+  stickers.forEach((sticker) => {
+    const card = document.createElement('div');
+    card.className = 'sticker-card';
+
+    const img = document.createElement('img');
+    img.src = sticker.src;
+    img.alt = sticker.name;
+    card.appendChild(img);
+
+    const panel = document.createElement('div');
+
+    const meta = document.createElement('div');
+    meta.className = 'sticker-meta';
+    meta.innerHTML = `<span>${sticker.name}</span><span>x${sticker.quantity}</span>`;
+    panel.appendChild(meta);
+
+    const fields = document.createElement('div');
+    fields.className = 'sticker-fields';
+
+    fields.appendChild(buildNumberField('Largura', fromMm(sticker.widthMm, unitLabel), unitLabel, (val) => {
+      sticker.widthMm = toMm(parseFloat(val) || 0, unitLabel);
+      packAndRender();
+    }));
+
+    fields.appendChild(buildNumberField('Altura', fromMm(sticker.heightMm, unitLabel), unitLabel, (val) => {
+      sticker.heightMm = toMm(parseFloat(val) || 0, unitLabel);
+      packAndRender();
+    }));
+
+    fields.appendChild(buildNumberField('Quantidade', sticker.quantity, '', (val) => {
+      sticker.quantity = Math.max(parseInt(val, 10) || 0, 0);
+      packAndRender();
+    }));
+
+    fields.appendChild(buildNumberField('Contorno', fromMm(sticker.contourMm, unitLabel), unitLabel, (val) => {
+      sticker.contourMm = toMm(parseFloat(val) || 0, unitLabel);
+      packAndRender();
+    }));
+
+    fields.appendChild(buildNumberField('Margem extra', fromMm(sticker.extraGapMm, unitLabel), unitLabel, (val) => {
+      sticker.extraGapMm = toMm(parseFloat(val) || 0, unitLabel);
+      packAndRender();
+    }));
+
+    const colorField = document.createElement('label');
+    colorField.className = 'field';
+    colorField.innerHTML = '<span>Cor do contorno</span>';
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.value = sticker.contourColor;
+    colorInput.addEventListener('input', (e) => {
+      sticker.contourColor = e.target.value;
+      renderPreview();
+    });
+    colorField.appendChild(colorInput);
+    fields.appendChild(colorField);
+
+    const rotationField = document.createElement('label');
+    rotationField.className = 'field';
+    rotationField.innerHTML = '<span>Permitir rotação</span>';
+    const rotationToggle = document.createElement('input');
+    rotationToggle.type = 'checkbox';
+    rotationToggle.checked = sticker.allowRotation;
+    rotationToggle.addEventListener('change', (e) => {
+      sticker.allowRotation = e.target.checked;
+      packAndRender();
+    });
+    rotationField.appendChild(rotationToggle);
+    fields.appendChild(rotationField);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.className = 'ghost';
+    removeBtn.textContent = 'Remover';
+    removeBtn.addEventListener('click', () => {
+      stickers = stickers.filter((s) => s.id !== sticker.id);
+      packAndRender();
+      renderStickerList();
+    });
+
+    panel.appendChild(fields);
+    panel.appendChild(removeBtn);
+    card.appendChild(panel);
+
+    stickerList.appendChild(card);
+  });
+}
+
+function buildNumberField(label, value, unitLabel, onChange) {
+  const wrapper = document.createElement('label');
+  wrapper.className = 'field';
+  const span = document.createElement('span');
+  span.textContent = unitLabel ? `${label} (${unitLabel})` : label;
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '0';
+  input.step = '0.5';
+  input.value = Number(value || 0).toFixed(1);
+  input.addEventListener('input', (e) => onChange(e.target.value));
+  wrapper.append(span, input);
+  return wrapper;
+}
+
+async function packAndRender() {
+  const payload = buildPayload();
+  try {
+    const response = await fetch('/pack', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) throw new Error('Erro ao comunicar com o planejador');
+    const data = await response.json();
+    pages = data.pages || [emptyPage()];
+  } catch (err) {
+    pages = fallbackPack(payload);
+  }
+  currentPageIndex = 0;
+  renderPreview();
+  updateSummary();
+}
+
+function buildPayload() {
+  const { width, height } = getSheetSize();
+  const marginMm = toMm(parseFloat(marginInput.value) || 0, currentUnit);
+  const gapMm = toMm(parseFloat(gapInput.value) || 0, currentUnit);
+
+  return {
+    sheetWidthMm: width,
+    sheetHeightMm: height,
+    marginMm,
+    gapMm,
+    stickers: stickers.map((sticker) => ({
+      id: sticker.id,
+      name: sticker.name,
+      widthMm: sticker.widthMm,
+      heightMm: sticker.heightMm,
+      quantity: sticker.quantity,
+      contourMm: sticker.contourMm,
+      contourColor: sticker.contourColor,
+      allowRotation: sticker.allowRotation,
+      extraGapMm: sticker.extraGapMm,
+    })),
+  };
+}
+
+function fallbackPack(payload) {
+  const { sheetWidthMm: sheetWidth, sheetHeightMm: sheetHeight, marginMm: margin, gapMm: gap } = payload;
+  const placements = [];
+  let x = margin;
+  let y = margin;
+  let rowHeight = 0;
+  let pagesLocal = [];
+
+  const expand = [];
+  payload.stickers.forEach((sticker) => {
+    const qty = Math.max(sticker.quantity, 0);
+    for (let i = 0; i < qty; i += 1) {
+      expand.push({ ...sticker });
+    }
+  });
+
+  const startPage = () => {
+    placements.length = 0;
+    x = margin;
+    y = margin;
+    rowHeight = 0;
+    pagesLocal.push({ placements: [], sheetWidth, sheetHeight, margin });
+  };
+
+  startPage();
+
+  expand.forEach((item) => {
+    let placed = false;
+    const tryPlace = (w, h, rotated) => {
+      const innerGap = gap + (item.extraGapMm || 0);
+      if (x + w <= sheetWidth - margin && y + h <= sheetHeight - margin) {
+        pagesLocal[pagesLocal.length - 1].placements.push({
+          ...item,
+          x,
+          y,
+          width: w,
+          height: h,
+          rotated,
+        });
+        x += w + innerGap;
+        rowHeight = Math.max(rowHeight, h);
+        return true;
+      }
+      const newRowY = y + rowHeight + innerGap;
+      if (w <= sheetWidth - margin * 2 && newRowY + h <= sheetHeight - margin) {
+        x = margin;
+        y = newRowY;
+        rowHeight = h;
+        pagesLocal[pagesLocal.length - 1].placements.push({
+          ...item,
+          x,
+          y,
+          width: w,
+          height: h,
+          rotated,
+        });
+        x += w + innerGap;
+        return true;
+      }
+      return false;
+    };
+
+    const orientations = item.allowRotation ? [false, true] : [false];
+    orientations.some((rotated) => {
+      const w = rotated ? item.heightMm + item.contourMm * 2 : item.widthMm + item.contourMm * 2;
+      const h = rotated ? item.widthMm + item.contourMm * 2 : item.heightMm + item.contourMm * 2;
+      if (tryPlace(w, h, rotated)) {
+        placed = true;
+        return true;
+      }
+      return false;
+    });
+
+    if (!placed) {
+      startPage();
+      const w = item.widthMm + item.contourMm * 2;
+      const h = item.heightMm + item.contourMm * 2;
+      pagesLocal[pagesLocal.length - 1].placements.push({ ...item, x: margin, y: margin, width: w, height: h, rotated: false });
+      x = margin + w + gap;
+      rowHeight = h;
+    }
+  });
+
+  return pagesLocal;
+}
+
+function renderPreview() {
+  const page = pages[currentPageIndex] || pages[0];
+  if (!page) return;
+  const { sheetWidth, sheetHeight, placements, margin } = page;
+  sheetCanvas.innerHTML = '';
+  sheetCanvas.setAttribute('viewBox', `0 0 ${sheetWidth} ${sheetHeight}`);
+  sheetCanvas.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+
+  const outline = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  outline.setAttribute('x', 0);
+  outline.setAttribute('y', 0);
+  outline.setAttribute('width', sheetWidth);
+  outline.setAttribute('height', sheetHeight);
+  outline.setAttribute('fill', '#fff');
+  outline.setAttribute('stroke', '#d1e7d5');
+  outline.setAttribute('stroke-width', 1);
+  sheetCanvas.appendChild(outline);
+
+  const marginRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  marginRect.setAttribute('x', margin);
+  marginRect.setAttribute('y', margin);
+  marginRect.setAttribute('width', sheetWidth - margin * 2);
+  marginRect.setAttribute('height', sheetHeight - margin * 2);
+  marginRect.setAttribute('fill', 'none');
+  marginRect.setAttribute('stroke-dasharray', '8 4');
+  marginRect.setAttribute('stroke', '#a0d7ad');
+  marginRect.setAttribute('stroke-width', 0.8);
+  sheetCanvas.appendChild(marginRect);
+
+  placements.forEach((item) => {
+    const contour = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    contour.setAttribute('x', item.x);
+    contour.setAttribute('y', item.y);
+    contour.setAttribute('width', item.width);
+    contour.setAttribute('height', item.height);
+    contour.setAttribute('rx', 2);
+    contour.setAttribute('fill', `${item.contourColor || '#22c55e'}22`);
+    contour.setAttribute('stroke', item.contourColor || '#22c55e');
+    contour.setAttribute('stroke-width', Math.max(item.contourMm || 0.5, 0.5));
+    sheetCanvas.appendChild(contour);
+
+    const padding = (item.contourMm || 0) * 2;
+    const innerW = Math.max(item.width - padding, 1);
+    const innerH = Math.max(item.height - padding, 1);
+    const image = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+    image.setAttributeNS('http://www.w3.org/1999/xlink', 'href', item.src || findSticker(item.id)?.src || '');
+    image.setAttribute('x', item.x + (padding / 2));
+    image.setAttribute('y', item.y + (padding / 2));
+    image.setAttribute('width', innerW);
+    image.setAttribute('height', innerH);
+    image.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    sheetCanvas.appendChild(image);
+  });
+
+  pageIndicator.textContent = `Página ${currentPageIndex + 1} de ${pages.length}`;
+}
+
+function findSticker(id) {
+  return stickers.find((s) => s.id === id);
+}
+
+function changePage(delta) {
+  if (!pages.length) return;
+  currentPageIndex = (currentPageIndex + delta + pages.length) % pages.length;
+  renderPreview();
+  updateSummary();
+}
+
+function updateSummary() {
+  const unitLabel = previewUnit.value;
+  const page = pages[currentPageIndex] || pages[0];
+  summaryBadges.innerHTML = '';
+  if (!page) return;
+  const totalStickers = stickers.reduce((acc, s) => acc + (s.quantity || 0), 0);
+  const areaSheet = page.sheetWidth * page.sheetHeight;
+  const areaUsed = page.placements.reduce((acc, p) => acc + p.width * p.height, 0);
+  const usage = ((areaUsed / areaSheet) * 100).toFixed(1);
+
+  const badges = [
+    `${totalStickers} adesivos no lote`,
+    `${pages.length} página(s)`,
+    `Uso da folha: ${usage}%`,
+    `Margem: ${fromMm(page.margin, unitLabel).toFixed(1)} ${unitLabel}`,
+  ];
+
+  badges.forEach((text) => {
+    const span = document.createElement('span');
+    span.textContent = text;
+    summaryBadges.appendChild(span);
+  });
+}
+
+// bootstrap
+renderStickerList();
+renderPreview();
+updateSummary();


### PR DESCRIPTION
## Summary
- replace legacy ping pong page with neumorphic sticker planner UI and controls
- add JS logic for uploads, per-sticker sizing, contour, quantities, unit conversions, and live sheet preview with paging
- introduce Flask backend packing endpoint and update docs with run instructions

## Testing
- python -m py_compile app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942ced00c1c8327bf7d479f02050ae7)